### PR TITLE
Add docker specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Alternatively you can use the pre-build images from:
 - https://gitlab.com/caroga/commentoplusplus-docker
 - https://hub.docker.com/r/caroga/commentoplusplus
 
-Instructions for configuring the docker image can be found here. Are you missing a version? Please contact @caroga [here](https://gitlab.com/caroga/commentoplusplus-docker).
+Instructions for configuring the docker image can be found [here](https://docs.commento.io/installation/self-hosting/on-your-server/docker.html). Are you missing a version? Please contact @caroga [here](https://gitlab.com/caroga/commentoplusplus-docker).
 
 ### Finally
 


### PR DESCRIPTION
As a result of switching from Commento to Commento++ for the time being I've setup a small pipeline that will create Commento++ docker images.
They can be found on gitlab and hub.docker.com, they are mirrored.

I've added this to the documentation as I thought this repo would benefit from this.

**Links**
- https://hub.docker.com/r/caroga/commentoplusplus
- https://gitlab.com/caroga/commentoplusplus-docker