### PR TITLE
Reload root element during reInit process

### DIFF
--- a/frontend/js/commento.js
+++ b/frontend/js/commento.js
@@ -2455,6 +2455,7 @@
   global.reInit = function(options) {
     pageId = options.pageId || pageId;
     ID_ROOT = options.idRoot || ID_ROOT;
+    root = $(ID_ROOT);
     noFonts = options.noFonts || noFonts;
     hideDeleted = options.hideDeleted || hideDeleted;
     cssOverride = options.cssOverride || cssOverride;


### PR DESCRIPTION
This occurred to me when trying to integrate with a Nuxt project.  It appears that if the ID_ROOT element is recreate with dynamic content, the old reference to it will be set to null which causes this line to fail

```
  root.innerHTML = "";
```

The simple fix is to re-assign the root before refresh all.
