### PR TITLE
Fix cross origin link

### DIFF
--- a/frontend/js/commento.js
+++ b/frontend/js/commento.js
@@ -447,6 +447,7 @@
 
     attrSet(a, "href", "https://github.com/souramoo/commentoplusplus");
     attrSet(a, "target", "_blank");
+    attrSet(a, "rel", "noreferrer");
 
     text.innerText = "Commento++";
 


### PR DESCRIPTION
Links to cross-origin destinations are unsafe if the `rel=noreferrer` or `rel=noopener` parameter is not set.

## Fixes
Part of #51 