### PR TITLE
Add GitHub Actions workflow for automating Docker Image building

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag caroga/commentoplusplus:latest
+
+    - name: Login to Docker Hub
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      
+    - name: Tag the image
+      run: docker tag caroga/commentoplusplus:latest caroga/commentoplusplus:"$TAG"
+      env:
+        TAG: ${{ github.event.release.tag_name }}
+        
+    - name: Push the image to Docker Hub
+      run: docker push caroga/commentoplusplus:latest && docker push caroga/commentoplusplus:"$TAG"
+      env:
+        TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This is for Issue #57.

Create docker-image.yml to automate building and pushing docker images to Docker Hub after a release has been published on GitHub.

Secret variable DOCKER_PASSWORD and DOCKER_USERNAME must be add to the repo for this to work.