### PR TITLE
Add QUEMU and Docker Buildx as to allow cross-platform docker builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  PLATFORMS: amd64,arm,arm64,riscv64
+
 jobs:
   build:
 
@@ -11,6 +14,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: ${{ env.PLATFORMS }}
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        install: true
+        version: latest
+        driver-opts: image=moby/buildkit:latest
     
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag caroga/commentoplusplus:latest


### PR DESCRIPTION
I am an owner of 32 bit ARM as well as riscv64 systems, and would love to use the docker hub image out of the box.

From what I can tell, with the dockerx command makes this as easy as it goes.

These two jobs sets up QEMU and adds support for `amd64,arm,arm64,riscv64`, then sets up docker build command as an alias to docker buildx.

The configuration is inspired by the [GitHub Action](https://github.com/docker/setup-buildx-action) documentation as well as the [phusion baseimage-docker](https://github.com/phusion/baseimage-docker/blob/master/.github/workflows/main.yml) workflow.