### PR TITLE
Align golang version configuraiton

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.15
 
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     triggers:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,10 @@ stages:
   - docker-registry-master
   - docker-registry-tags
 
+variables:
+  GIT_DEPTH: 10
+  GO_VERSION: "1.15"
+
 build-src:
   stage: build-src
   image: debian:buster
@@ -34,7 +38,7 @@ build-docker:
 
 go-test:
   stage: go-test
-  image: golang:1.14
+  image: golang:${GO_VERSION}
   services:
     - postgres:9.6
   variables:
@@ -56,7 +60,7 @@ go-test:
 
 go-fmt:
   stage: go-fmt
-  image: golang:1.14
+  image: golang:${GO_VERSION}
   except:
     - master
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ stages:
   - docker-registry-tags
 
 variables:
-  GIT_DEPTH: 10
+  GIT_DEPTH: "10"
   GO_VERSION: "1.15"
 
 build-src:

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module gitlab.com/commento/commento/api
 
-go 1.12
+go 1.15
 
 require (
 	cloud.google.com/go v0.79.0 // indirect


### PR DESCRIPTION
In the root Dockerfile golang:1.15 is used.

This PR aligns the golang version specified in the GitLab CI, in the Circles CI, and for the backend itself.

Lastly it sets the GitLab CI git depth, which configures the CI to use shallow cloning, as it then only checks out the last 10 commits (at least in theory making the CI faster).

A small question: This project is using GitHub Actions, GitLab CI and CircleCI, all at the same time? If for example CircleCI isnt used, perhaps we can just remove the pipeline config.

https://docs.gitlab.com/ee/ci/runners/configure_runners.html#shallow-cloning