### PR TITLE
Add build and test GitHub Workflow based on the GitLab CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,7 @@
 name: Build CI
 
 on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - "*"
+  workflow_dispatch:
 
 jobs:
   build-frontend:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build CI
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - "*"
+
+jobs:
+  build-frontend:
+    name: Build frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Build devel
+        run: make --directory=frontend devel
+
+      - name: Build prod
+        run: make --directory=frontend prod
+
+  build-api:
+    name: Build API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build devel
+        run: make --directory=api devel
+
+      - name: Build prod
+        run: make --directory=api prod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,7 @@
 name: Test CI
 
 on:
-  push:
-    branches-ignore:
-      - master
-    tags-ignore:
-      - "*"
+  workflow_dispatch:
 
 jobs:
   test-api:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test CI
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - "*"
+
+jobs:
+  test-api:
+    name: Test API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Test
+        run: make --directory=api test
+
+      - name: Lint
+        run: cd api && test -z "$(go fmt)"

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -16,4 +16,6 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   test:
+    # Tests do no compile yet, see https://github.com/souramoo/commentoplusplus/issues/93
+    if: ${{ false }}
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - "*"
+
+env:
+  GO_VERSION: "1.15"
+  NODE_VERSION: "12.x"
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  test:
+    uses: ./.github/workflows/test.yml


### PR DESCRIPTION
The Build and Test are executed on all git commits except for master commits or any git tag pushes.

I understand this as the equivalent of the following GitLab CI.

```yaml
go-test:
  except:
    - master
    - tags
```