### PR TITLE
Fix guest comments falsely approved later in logic

### DIFF
--- a/api/comment_new.go
+++ b/api/comment_new.go
@@ -131,6 +131,8 @@ func commentNewHandler(w http.ResponseWriter, r *http.Request) {
 		state = "unapproved"
 	} else if commenterHex == "anonymous" && d.ModerateAllAnonymous {
 		state = "unapproved"
+	} else if *x.CommenterToken == "anonymous" && d.ModerateAllAnonymous {
+		state = "unapproved"
 	} else if d.AutoSpamFilter && isSpam(*x.Domain, getIp(r), getUserAgent(r), commenterName, commenterEmail, commenterLink, *x.Markdown) {
 		state = "flagged"
 	} else {


### PR DESCRIPTION
This hotfixes a bug, where if moderation of anonymous comments is enabled, guest comments are wrongly approved later on. Because the logic on api/comment_new.go:128 overwrites the comment state and follows a default allow logic.

The bug exists because if using guest posts, there will be a name assigned and the "commenterHex" contains the new guest-name and does not contain "anonymous" anymore. The logic fails to catch this.

Actually all the states assignments beforehand (line 96, 107) are not necessary, if there is some logic block later, which redefines the states.

Could be part of some overhaul, to streamline state assignment.