### PR TITLE
rework Dockerfile (dependencies, distroless, non-root)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,34 @@
-# backend build (api server)
-FROM golang:1.15-alpine AS api-build
-RUN apk add --no-cache --update bash dep make git curl g++
-
+# Build-time variables
 ARG RELEASE=prod
+ARG ALPINE_VERSION=3.15
+ARG GOLANG_VERSION=1.15
+ARG NODE_VERSION=14
+
+# backend build (api server)
+FROM golang:${GOLANG_VERSION}-alpine AS api-build
+RUN apk add --no-cache bash dep make git curl g++
+
+ARG RELEASE
 COPY ./api /go/src/commento/api/
 WORKDIR /go/src/commento/api
 RUN make ${RELEASE} -j$(($(nproc) + 1))
 
 
 # frontend build (html, js, css, images)
-FROM node:12-alpine AS frontend-build
-RUN apk add --no-cache --update bash make python2 g++
+FROM node:${NODE_VERSION}-alpine AS frontend-build
+RUN apk add --no-cache bash make python2 g++
 
-ARG RELEASE=prod
+ARG RELEASE
 COPY ./frontend /commento/frontend
 WORKDIR /commento/frontend/
 RUN make ${RELEASE} -j$(($(nproc) + 1))
 
 
 # templates and db build
-FROM alpine:3.13 AS templates-db-build
-RUN apk add --no-cache --update bash make
+FROM alpine:${ALPINE_VERSION} AS templates-db-build
+RUN apk add --no-cache bash make
 
-ARG RELEASE=prod
+ARG RELEASE
 COPY ./templates /commento/templates
 WORKDIR /commento/templates
 RUN make ${RELEASE} -j$(($(nproc) + 1))
@@ -33,10 +39,9 @@ RUN make ${RELEASE} -j$(($(nproc) + 1))
 
 
 # final image
-FROM alpine:3.13
-RUN apk add --no-cache --update ca-certificates
+FROM gcr.io/distroless/static-debian11
 
-ARG RELEASE=prod
+ARG RELEASE
 
 COPY --from=api-build /go/src/commento/api/build/${RELEASE}/commento /commento/commento
 COPY --from=frontend-build /commento/frontend/build/${RELEASE}/js /commento/js
@@ -51,4 +56,5 @@ COPY --from=templates-db-build /commento/db/build/${RELEASE}/db /commento/db/
 EXPOSE 8080
 WORKDIR /commento/
 ENV COMMENTO_BIND_ADDRESS="0.0.0.0"
+USER nobody
 ENTRYPOINT ["/commento/commento"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG RELEASE=prod
 ARG ALPINE_VERSION=3.15
 ARG GOLANG_VERSION=1.15
-ARG NODE_VERSION=14
+ARG NODE_VERSION=16
 
 # backend build (api server)
 FROM golang:${GOLANG_VERSION}-alpine AS api-build

--- a/api/Makefile
+++ b/api/Makefile
@@ -25,15 +25,15 @@ clean:
 # later down the line).
 
 devel-go:
-	GO111MODULE=on go mod vendor
-	GO111MODULE=on go build -mod=vendor -v -o $(GO_DEVEL_BUILD_BINARY) -ldflags "-X main.version=$(shell git describe --tags) -X main.debug=true"
+	GO111MODULE=on CGO_ENABLED=0 go mod vendor
+	GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -v -o $(GO_DEVEL_BUILD_BINARY) -ldflags "-X main.version=$(shell git describe --tags) -X main.debug=true"
 
 prod-go:
-	GO111MODULE=on go mod vendor
-	GO111MODULE=on go build -mod=vendor -v -o $(GO_PROD_BUILD_BINARY) -ldflags "-X main.version=$(shell git describe --tags)"
+	GO111MODULE=on CGO_ENABLED=0 go mod vendor
+	GO111MODULE=on CGO_ENABLED=0 go build -mod=vendor -v -o $(GO_PROD_BUILD_BINARY) -ldflags "-X main.version=$(shell git describe --tags)"
 
 test-go:
-	GO111MODULE=on go mod vendor
+	GO111MODULE=on CGO_ENABLED=0 go mod vendor
 	go test -v .
 
 $(shell mkdir -p $(GO_DEVEL_BUILD_DIR) $(GO_PROD_BUILD_DIR))


### PR DESCRIPTION
I've had this in mind for quite some time (also thanks to [this PR on the original project](https://gitlab.com/commento/commento/-/merge_requests/188) for the inspiration!).

We disable CGO to make sure we produce static builds that can run in a "distroless" environment (that is, a minimal environment providing nothing more than ca-certificates and the like). That will reduce the final image size and reduce the attack surface of the container for those who deploy Commento that way.

We don't need to run Commento as root. That was the case before (if no user is specified, root is used by default), and this meant that on traditional Docker installations, root in the container was also root on the host, and that is not desirable or needed since there isn't any volume to mount, so the change should be painless even for existing installs.

I took the liberty to update the other images used for the build, and I reorganized the Dockerfile to make it so the main build-time variables are at the top. This makes it easier to maintain. Current version of `node-sass` prevents building with Node v16 (it would be nice to update to the last LTS), so let's use Node v14 for now.

Also, what do you say about publishing the Docker image in the [GitHub Container Registry](https://docs.github.com/en/actions/publishing-packages/publishing-docker-images) and link it to this repository? The current Action doesn't seem to be enabled too (the Docker Hub image hasn't been updated for quite a while).