### PR TITLE
Fix Moderation with Wildcard Domains

### DIFF
--- a/api/domain_moderator.go
+++ b/api/domain_moderator.go
@@ -42,7 +42,7 @@ func isDomainModerator(domain string, email string) (bool, error) {
 		SELECT EXISTS (
 			SELECT 1
 			FROM moderators
-			WHERE domain=$1 AND email=$2
+			WHERE $1 LIKE domain AND email=$2
 		);
 	`
 	row := db.QueryRow(statement, domain, email)

--- a/api/domain_ownership_verify.go
+++ b/api/domain_ownership_verify.go
@@ -11,7 +11,7 @@ func domainOwnershipVerify(ownerHex string, domain string) (bool, error) {
 		SELECT EXISTS (
 			SELECT 1
 			FROM domains
-			WHERE ownerHex=$1 AND domain=$2
+			WHERE ownerHex=$1 AND $2 LIKE domain
 		);
 	`
 	row := db.QueryRow(statement, ownerHex, domain)


### PR DESCRIPTION
When using a wildcard domain, moderation of comments did not work at all.
These two changes fix it for both the e-mail API and the web API.