### PR TITLE
Simplify email sending

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.16
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
 	github.com/russross/blackfriday v1.5.2
+	github.com/xhit/go-simple-mail/v2 v2.11.0 // indirect
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/api/go.sum
+++ b/api/go.sum
@@ -160,6 +160,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208 h1:PM5hJF7HVfNWmCjMdEfbuOBNXSVF2cMFGgQTPdKCbwM=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208/go.mod h1:BzWtXXrXzZUvMacR0oF/fbDDgUPO8L36tDMmRAf14ns=
+github.com/xhit/go-simple-mail/v2 v2.11.0 h1:o/056V50zfkO3Mm5tVdo9rG3ryg4ZmJ2XW5GMinHfVs=
+github.com/xhit/go-simple-mail/v2 v2.11.0/go.mod h1:b7P5ygho6SYE+VIqpxA6QkYfv4teeyG4MKqB3utRu98=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/api/smtp_configure.go
+++ b/api/smtp_configure.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"net/smtp"
 	"os"
 )
 
 var smtpConfigured bool
-var smtpAuth smtp.Auth
 
 func smtpConfigure() error {
 	username := os.Getenv("SMTP_USERNAME")
@@ -25,11 +23,8 @@ func smtpConfigure() error {
 		return errorMissingSmtpAddress
 	}
 
-	logger.Infof("configuring smtp: %s", host)
 	if username == "" || password == "" {
 		logger.Warningf("no SMTP username/password set, Commento will assume they aren't required")
-	} else {
-		smtpAuth = smtp.PlainAuth("", username, password, host)
 	}
 	smtpConfigured = true
 	return nil

--- a/api/smtp_send.go
+++ b/api/smtp_send.go
@@ -1,35 +1,41 @@
 package main
 
 import (
-	"fmt"
-	"net/mail"
-	"net/smtp"
+	"crypto/tls"
+	"github.com/xhit/go-simple-mail/v2"
+	stdmail "net/mail"
 	"os"
+	"strconv"
 )
 
 func smtpSendMail(toAddress string, toName string, contentType string, subject string, body string) error {
-	from := mail.Address{"Commento", os.Getenv("SMTP_FROM_ADDRESS")}
-	to := mail.Address{toName, toAddress}
+	server := mail.NewSMTPClient()
 
-	// Setup headers
-	headers := make(map[string]string)
-	headers["To"] = to.String()
-	headers["Subject"] = subject
-	if contentType == "" {
-		headers["Content-Type"] = "text/plain; charset=UTF-8"
-	} else {
-		headers["Content-Type"] = contentType
+	// These are validated in `smtpConfigure`
+	server.Host = os.Getenv("SMTP_HOST")
+	server.Port, _ = strconv.Atoi(os.Getenv("SMTP_PORT"))
+	server.Username = os.Getenv("SMTP_USERNAME")
+	server.Password = os.Getenv("SMTP_PASSWORD")
+
+	server.TLSConfig = &tls.Config{InsecureSkipVerify: os.Getenv("SMTP_SKIP_HOST_VERIFY") == "true"}
+
+	smtpClient, err := server.Connect()
+
+	if err != nil {
+		return err
 	}
 
-	// Setup message
-	message := ""
-	for k, v := range headers {
-		message += fmt.Sprintf("%s: %s\r\n", k, v)
+	fromAddress := stdmail.Address{"Commento", os.Getenv("SMTP_FROM_ADDRESS")}
+	to := stdmail.Address{toName, toAddress}
+	email := mail.NewMSG()
+	email.SetFrom(fromAddress.String())
+	email.AddTo(to.String())
+	email.SetSubject(subject)
+	email.SetBody(mail.TextPlain, body)
+
+	if email.Error != nil {
+		return email.Error
 	}
-	message += "\r\n" + body
 
-	// Connect to the SMTP Server
-	servername := os.Getenv("SMTP_HOST") + ":" + os.Getenv("SMTP_PORT")
-
-	return smtp.SendMail(servername, smtpAuth, from.String(), []string{to.String()}, []byte(message))
+	return email.Send(smtpClient)
 }

--- a/api/smtp_send.go
+++ b/api/smtp_send.go
@@ -1,27 +1,20 @@
 package main
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net"
 	"net/mail"
 	"net/smtp"
 	"os"
 )
 
 func smtpSendMail(toAddress string, toName string, contentType string, subject string, body string) error {
-	from := mail.Address{"", os.Getenv("SMTP_FROM_ADDRESS")}
-	to := mail.Address{"", toAddress}
+	from := mail.Address{"Commento", os.Getenv("SMTP_FROM_ADDRESS")}
+	to := mail.Address{toName, toAddress}
 
 	// Setup headers
 	headers := make(map[string]string)
+	headers["To"] = to.String()
 	headers["Subject"] = subject
-	headers["From"] = "Commento <" + from.String() + ">"
-	if toName == "" {
-		headers["To"] = to.String()
-	} else {
-		headers["To"] = toName + " <" + to.String() + ">"
-	}
 	if contentType == "" {
 		headers["Content-Type"] = "text/plain; charset=UTF-8"
 	} else {
@@ -38,57 +31,5 @@ func smtpSendMail(toAddress string, toName string, contentType string, subject s
 	// Connect to the SMTP Server
 	servername := os.Getenv("SMTP_HOST") + ":" + os.Getenv("SMTP_PORT")
 
-	host, _, _ := net.SplitHostPort(servername)
-
-	// TLS config
-	tlsconfig := &tls.Config{
-		ServerName: host,
-	}
-	if os.Getenv("SMTP_SKIP_HOST_VERIFY") == "true" {
-		tlsconfig.InsecureSkipVerify = true
-	}
-
-	c, err := smtp.Dial(servername)
-	if err != nil {
-		return err
-	}
-
-	err = c.StartTLS(tlsconfig)
-	if err != nil {
-		return err
-	}
-
-	if smtpAuth != nil {
-		err = c.Auth(smtpAuth)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = c.Mail(from.Address)
-	if err != nil {
-		return err
-	}
-
-	err = c.Rcpt(to.Address)
-	if err != nil {
-		return err
-	}
-
-	w, err := c.Data()
-	if err != nil {
-		return err
-	}
-
-	_, err = w.Write([]byte(message))
-	if err != nil {
-		return err
-	}
-
-	err = w.Close()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return smtp.SendMail(servername, smtpAuth, from.String(), []string{to.String()}, []byte(message))
 }


### PR DESCRIPTION
This will hopefully fix a number of issues around email sending issues. The current implementation is very low level, and with email that's almost certainly a bad idea.

I first tried this with `smtp.SendMail`, which made things a lot cleaner, but using a library should help even more.

Should fix: 
- #88
- #53
- #15

I could do with a lot of help testing this in different environments and with different providers.

I'm not entirely happy with how validation and sending are 2 separate steps - perhaps that wants integrating / a rethink?

(Disclaimer: I'm not a frequent Go writer)