### PR TITLE
Improve anonymous only (all authentication disabled) experience

### DIFF
--- a/frontend/js/commento.js
+++ b/frontend/js/commento.js
@@ -716,8 +716,8 @@
     markdownButton.innerHTML = i18n("<b>M &#8595;</b> &nbsp; Markdown Help?");
 
     if (anonymousOnly) {
-      anonymousCheckbox.checked = true;
-      anonymousCheckbox.setAttribute("disabled", true);
+      anonymousCheckbox.checked = false;
+      anonymousCheckbox.setAttribute("enabled", true);
     }
     onclick(anonymousCheckbox, checkAnonymous, id);
     if(isAuthenticated) {
@@ -1033,7 +1033,9 @@
 
 
   function scorify(score) {
-    if (score !== 1 && score !== -1) {
+    if (anonymousOnly) {
+      return "";
+    } else if (score !== 1 && score !== -1) {
       return score + i18n(" points");
     } else {
       return score + i18n(" point");
@@ -1267,7 +1269,7 @@
         append(options, collapse);
       }
 
-      if (!comment.deleted  && (!isFrozen && !isLocked)) {
+      if (!comment.deleted  && (!anonymousOnly) && (!isFrozen && !isLocked)) {
         append(options, downvote);
         append(options, upvote);
       }


### PR DESCRIPTION
* Enable the anonymous checkbox so we can choose to enter a name,
  even when only anonymous is enabled
* Disable voting when only anonymous is enabled, since we can't
  vote anyway
* Hide the scores when only anonymous is enabled, since no one can
  vote anyway

PS. This would also close issue #35 