### PR TITLE
Add arm7 support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,4 +50,4 @@ jobs:
           ghcr.io/souramoo/commentoplusplus:${{ steps.previoustag.outputs.tag }}
         # build on feature branches, push only on main branch
         push: ${{ github.ref == 'refs/heads/master' }}
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
This is useful for most Raspberry Pi's that still run 32-bit OS's. This way they don't need to be formatted to a 64 bit OS to use commentoplusplus