### PR TITLE
add STARTTLS email encryption option

### DIFF
--- a/api/smtp_send.go
+++ b/api/smtp_send.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"crypto/tls"
-	"github.com/xhit/go-simple-mail/v2"
 	stdmail "net/mail"
 	"os"
 	"strconv"
+
+	mail "github.com/xhit/go-simple-mail/v2"
 )
 
 func smtpSendMail(toAddress string, toName string, contentType string, subject string, body string) error {
@@ -17,7 +18,14 @@ func smtpSendMail(toAddress string, toName string, contentType string, subject s
 	server.Username = os.Getenv("SMTP_USERNAME")
 	server.Password = os.Getenv("SMTP_PASSWORD")
 
-	server.TLSConfig = &tls.Config{InsecureSkipVerify: os.Getenv("SMTP_SKIP_HOST_VERIFY") == "true"}
+	if os.Getenv("USE_STARTTLS") == "true" {
+		server.Encryption = mail.EncryptionSTARTTLS
+	}
+
+	server.TLSConfig = &tls.Config{
+		InsecureSkipVerify: os.Getenv("SMTP_SKIP_HOST_VERIFY") == "true",
+		ServerName:         os.Getenv("SMTP_HOST"),
+	}
 
 	smtpClient, err := server.Connect()
 


### PR DESCRIPTION
As mentioned in #133, STARTTLS did not seem to work for me.

This pull request uses the `USE_STARTTLS` environment variable to enable STARTTLS encryption or not.

To get it working for me, I also had to add the `ServerName` property in the `server.TLSConfig` variable. If I understand correctly, it shouldn't be a problem to always add the `ServerName` property.

I guess this should be tested with some other email setups before merging.