### PR TITLE
Set button role on markdown help link

### DIFF
--- a/frontend/js/commento.js
+++ b/frontend/js/commento.js
@@ -706,6 +706,7 @@
     attrSet(anonymousCheckboxLabel, "for", ID_ANONYMOUS_CHECKBOX + id);
     attrSet(guestName, "type", "text");
     attrSet(guestName, "placeholder", i18n("Your Name"));
+    attrSet(markdownButton, "role", "button");
 
     anonymousCheckboxLabel.innerText = i18n("Comment anonymously");
     if (edit === true) {


### PR DESCRIPTION
This lets browsers know it's actually a button, rather than a malformed `a` without a `href`.